### PR TITLE
Extract transfrom from a DB model only if is selected by the user

### DIFF
--- a/lua/autorun/trackassembly_init.lua
+++ b/lua/autorun/trackassembly_init.lua
@@ -84,7 +84,7 @@ local asmlib = trackasmlib; if(not asmlib) then -- Module present
 ------------ CONFIGURE ASMLIB ------------
 
 asmlib.InitBase("track","assembly")
-asmlib.SetOpVar("TOOL_VERSION","8.748")
+asmlib.SetOpVar("TOOL_VERSION","8.749")
 asmlib.SetIndexes("V" ,1,2,3)
 asmlib.SetIndexes("A" ,1,2,3)
 asmlib.SetIndexes("WV",1,2,3)

--- a/lua/autorun/trackassembly_init.lua
+++ b/lua/autorun/trackassembly_init.lua
@@ -84,7 +84,7 @@ local asmlib = trackasmlib; if(not asmlib) then -- Module present
 ------------ CONFIGURE ASMLIB ------------
 
 asmlib.InitBase("track","assembly")
-asmlib.SetOpVar("TOOL_VERSION","8.745")
+asmlib.SetOpVar("TOOL_VERSION","8.746")
 asmlib.SetIndexes("V" ,1,2,3)
 asmlib.SetIndexes("A" ,1,2,3)
 asmlib.SetIndexes("WV",1,2,3)

--- a/lua/autorun/trackassembly_init.lua
+++ b/lua/autorun/trackassembly_init.lua
@@ -84,7 +84,7 @@ local asmlib = trackasmlib; if(not asmlib) then -- Module present
 ------------ CONFIGURE ASMLIB ------------
 
 asmlib.InitBase("track","assembly")
-asmlib.SetOpVar("TOOL_VERSION","8.746")
+asmlib.SetOpVar("TOOL_VERSION","8.747")
 asmlib.SetIndexes("V" ,1,2,3)
 asmlib.SetIndexes("A" ,1,2,3)
 asmlib.SetIndexes("WV",1,2,3)

--- a/lua/autorun/trackassembly_init.lua
+++ b/lua/autorun/trackassembly_init.lua
@@ -84,7 +84,7 @@ local asmlib = trackasmlib; if(not asmlib) then -- Module present
 ------------ CONFIGURE ASMLIB ------------
 
 asmlib.InitBase("track","assembly")
-asmlib.SetOpVar("TOOL_VERSION","8.747")
+asmlib.SetOpVar("TOOL_VERSION","8.748")
 asmlib.SetIndexes("V" ,1,2,3)
 asmlib.SetIndexes("A" ,1,2,3)
 asmlib.SetIndexes("WV",1,2,3)

--- a/lua/autorun/trackassembly_init.lua
+++ b/lua/autorun/trackassembly_init.lua
@@ -84,7 +84,7 @@ local asmlib = trackasmlib; if(not asmlib) then -- Module present
 ------------ CONFIGURE ASMLIB ------------
 
 asmlib.InitBase("track","assembly")
-asmlib.SetOpVar("TOOL_VERSION","8.741")
+asmlib.SetOpVar("TOOL_VERSION","8.743")
 asmlib.SetIndexes("V" ,1,2,3)
 asmlib.SetIndexes("A" ,1,2,3)
 asmlib.SetIndexes("WV",1,2,3)

--- a/lua/autorun/trackassembly_init.lua
+++ b/lua/autorun/trackassembly_init.lua
@@ -84,7 +84,7 @@ local asmlib = trackasmlib; if(not asmlib) then -- Module present
 ------------ CONFIGURE ASMLIB ------------
 
 asmlib.InitBase("track","assembly")
-asmlib.SetOpVar("TOOL_VERSION","8.743")
+asmlib.SetOpVar("TOOL_VERSION","8.745")
 asmlib.SetIndexes("V" ,1,2,3)
 asmlib.SetIndexes("A" ,1,2,3)
 asmlib.SetIndexes("WV",1,2,3)
@@ -945,11 +945,11 @@ if(CLIENT) then
                       if(luapad.Frame) then luapad.Frame:SetVisible(true)
                       else asmlib.SetAsmConvar(oPly, "*luapad", gsToolNameL) end
                       luapad.AddTab("["..defTab.Nick.."]"..pnSelf:GetText(), fileRead(sFile, "DATA"), sDsv);
-                      if(defTab.Nick == "PIECES") then local sCat = fDSV:format(sPref, "CATEGORY")
-                        if(fileExists(sCat,"DATA")) then
+                      if(defTab.Nick == "PIECES") then -- Load the categoty provider for this DSV
+                        local sCat = fDSV:format(sPref, "CATEGORY"); if(fileExists(sCat,"DATA")) then
                           luapad.AddTab("[CATEGORY]"..pnSelf:GetText(), fileRead(sCat, "DATA"), sDsv);
-                        end
-                      end
+                        end -- This is done so we can distinguish between luapad and other panels
+                      end -- Luapad is designed not to be closed so we need to make it invisible
                       luapad.Frame:SetVisible(true); luapad.Frame:Center()
                       luapad.Frame:MakePopup(); conElements:Push({luapad.Frame})
                     end
@@ -957,7 +957,7 @@ if(CLIENT) then
                   function() fileDelete(sFile)
                     asmlib.LogInstance("Delete "..asmlib.GetReport1(sFile), sLog..".Button")
                     if(defTab.Nick == "PIECES") then local sCat = fDSV:format(sPref, "CATEGORY")
-                      if(fileExists(sCat,"DATA")) then fileDelete(sCat)
+                      if(fileExists(sCat,"DATA")) then fileDelete(sCat) -- Delete category when present
                         asmlib.LogInstance("Deleted "..asmlib.GetReport1(sCat), sLog..".Button") end
                     end; pnManage:Remove()
                   end
@@ -965,7 +965,7 @@ if(CLIENT) then
                 while(tOptions[iO]) do local sO = tostring(iO)
                   local sDescr = languageGetPhrase("tool."..gsToolNameL..".pn_externdb_bt"..sO)
                   pnMenu:AddOption(sDescr, tOptions[iO]):SetIcon(asmlib.ToIcon("pn_externdb_bt"..sO))
-                  iO = iO + 1 -- Loop trough the functions list and add to the menu
+                  iO = iO + 1 -- Loop trough the functions list and add them to the menu
                 end; pnMenu:Open()
               end
             else asmlib.LogInstance("File missing ["..tostring(iP).."]",sLog..".Button") end

--- a/lua/trackassembly/trackasmlib.lua
+++ b/lua/trackassembly/trackasmlib.lua
@@ -2238,7 +2238,7 @@ end
  * This function is used to check the correct offset and return it.
  * It also returns the normalized active point ID if needed
  * Updates current record origin and angle when they use attachments
- * oRec   > Record structure of a track piece persising in the cache
+ * oRec   > Record structure of a track piece stored in the cache
  * ivPoID > The POA offset ID to be checked and located
  * Returns a cache record and the converted to number offset ID
 ]]--
@@ -2282,13 +2282,13 @@ function LocatePOA(oRec, ivPoID)
       end -- Transform angle is decoded from the model and stored in the cache
       ---------- Point ----------
       if(sP:sub(1,1) == sD) then -- Check whenever point is disabled
-        ReloadPOA(tOA.O[cvX], tOA.O[cvY], tOA.O[cvZ]) -- Overwrite with the origin
+        ReloadPOA(tOA.O[cvX], tOA.O[cvY], tOA.O[cvZ]) -- Override with the origin
       else -- When the point is disabled take the origin otherwise try to process it
         if(IsNull(sP) or IsBlank(sP)) then -- In case of empty value or null use the origin
-          ReloadPOA(tOA.O[cvX], tOA.O[cvY], tOA.O[cvZ])  -- Overwrite with the origin
+          ReloadPOA(tOA.O[cvX], tOA.O[cvY], tOA.O[cvZ])  -- Override with the origin
         else -- When the point is empty use the origin otherwise decode the value
           if(not DecodePOA(sP)) then LogInstance("Point mismatch "..GetReport2(ID, oRec.Slot)) end
-        end -- The point already decoded an it is ready to be populated in the cache
+        end -- The point is already decoded and ready to be populated in the cache
       end; if(not IsHere(TransferPOA(tOA.P, "V"))) then LogInstance("Point transfer fail"); return nil end
     end -- Loop and transform all the POA configuration at once. Game model slot will be taken
   end; return stPOA, iPoID

--- a/lua/trackassembly/trackasmlib.lua
+++ b/lua/trackassembly/trackasmlib.lua
@@ -2237,8 +2237,10 @@ end
  * Locates an active point on the piece offset record.
  * This function is used to check the correct offset and return it.
  * It also returns the normalized active point ID if needed
+ * Updates current record origin and angle when they use attachments
  * oRec   > Record structure of a track piece
  * ivPoID > The POA offset ID to check and locate
+ * Returns a cache record and the converted to number offset ID
 ]]--
 function LocatePOA(oRec, ivPoID)
   if(not oRec) then LogInstance("Missing record"); return nil end
@@ -2668,7 +2670,7 @@ function CreateTable(sTable,defTab,bDelete,bReload)
     local qtCol = qtDef[iD]; if(qtCol) then return qtCol[1] end
     LogInstance("Mismatch "..GetReport(vD), tabDef.Nick); return nil
   end
-  -- Returns the colomn information by the given ID > 0
+  -- Returns the column information by the given ID > 0
   function self:GetColumnInfo(vD, vI)
     local iD = (tonumber(vD) or 0)
     local qtDef = self:GetDefinition()
@@ -2878,7 +2880,7 @@ function CreateTable(sTable,defTab,bDelete,bReload)
     local qtCmd = self:GetCommand()
     qtCmd.Commit = "COMMIT;"; return self
   end
-  -- Build create/drop/delete statement table of statemenrts
+  -- Build create/drop/delete statement table of statements
   function self:Create()
     local qtDef = self:GetDefinition()
     local qtCmd, iInd = self:GetCommand(), 1; qtCmd.STMT = "Create"
@@ -3236,7 +3238,7 @@ function ExportPanelDB(stPanel, bExp, makTab, sFunc)
       if(not cT or cT ~= sT) then -- Category has been changed
         F:Write("# Categorize [ "..sMoDB.." ]("..sT.."): "..tostring(WorkshopID(sT) or sMiss))
         F:Write("\n"); cT = sT -- Cache category name
-      end -- Otherwise just wite down the piece active point
+      end -- Otherwise just write down the piece active point
       F:Write("\""..sM.."\""..symSep.."\""..sT.."\""..symSep.."\""..sN.."\"")
       F:Write("\n"); iCnt = iCnt + 1
     end; F:Flush(); F:Close()
@@ -3627,7 +3629,7 @@ function SynchronizeDSV(sTable, tData, bRepl, sPref, sDelim)
       vID = tRow[iD-1]; nID, sID = tonumber(vID), tostring(vID)
       nID = (nID or (sID:sub(1,1) == symOff and iCnt or 0))
       -- Where the line ID must be read from. Skip the key itself and convert the disabled value
-      if(iCnt ~= nID) then -- Validate the line ID being in proper borders abd sequential
+      if(iCnt ~= nID) then -- Validate the line ID being in proper borders and sequential
           LogInstance("("..fPref.."@"..sTable.."@"..sKey..") Sync point ["
             ..tostring(iCnt).."] ID scatter "..GetReport3(vID, nID, sID))
           return false end; tRow[iD-1] = nID

--- a/lua/trackassembly/trackasmlib.lua
+++ b/lua/trackassembly/trackasmlib.lua
@@ -2251,7 +2251,7 @@ function LocatePOA(oRec, ivPoID)
     local sE = GetOpVar("OPSYM_ENTPOSANG") -- Extract transform from model
     for ID = 1, oRec.Size do tOA = oRec.Offs[ID] -- Index current offset
       local sO, sA = tOA.O.Slot, tOA.A.Slot -- Localize transform index slots
-      if(sO and sO:sub(1,1) = sE) then -- POA origin must extracted from the model
+      if(sO and sO:sub(1,1) == sE) then -- POA origin must extracted from the model
         local sO = sO:sub(2, -1) -- Read origin transform ID and try to index
         local vO, aA = GetTransformOA(oRec.Slot, sO) -- Read transform position/angle
         if(IsHere(vO)) then ReloadPOA(vO[cvX], vO[cvY], vO[cvZ]) -- Load origin into POA
@@ -2263,7 +2263,7 @@ function LocatePOA(oRec, ivPoID)
           LogInstance("Origin transfer "..GetReport(ID, oRec.Slot)) end
         LogInstance("Origin transform from model "..GetReport3(ID, sO, StringPOA(tOA.O, "V")))
       end -- Transform origin is decoded from the model and stored in the cache
-      if(sA and sA:sub(1,1) = sE) then -- POA angle must extracted from the model
+      if(sA and sA:sub(1,1) == sE) then -- POA angle must extracted from the model
         local sA = sA:sub(2, -1) -- Read angle transform ID and try to index
         local vO, aA = GetTransformOA(oRec.Slot, sA) -- Read transform position/angle
         if(IsHere(aA)) then ReloadPOA(aA[caP], aA[caY], aA[caR]) -- Load angle into POA

--- a/lua/weapons/gmod_tool/stools/trackassembly.lua
+++ b/lua/weapons/gmod_tool/stools/trackassembly.lua
@@ -1772,22 +1772,20 @@ end
 
 function TOOL:Think()
   if(not asmlib.IsInit()) then return end
+  local workmode = self:GetWorkingMode()
+  if(SERVER) then return end
   local model = self:GetModel()
-  if(asmlib.IsModel(model)) then
-    local workmode = self:GetWorkingMode()
-    if(CLIENT) then
-      local bO = asmlib.IsFlag("old_close_frame", asmlib.IsFlag("new_close_frame"))
-      local bN = asmlib.IsFlag("new_close_frame", inputIsKeyDown(KEY_E))
-      if(not bO and bN and inputIsKeyDown(KEY_LALT)) then
-        local oD = conElements:Pull() -- Retrieve a panel from the stack
-        if(asmlib.IsTable(oD)) then oD = oD[1] -- Extract panel from table
-          if(IsValid(oD)) then oD:SetVisible(false) end -- Make it invisible
-        else -- The temporary reference is not table then close it
-          if(IsValid(oD)) then oD:Close() end -- A `close` call, get it :D
-        end -- Shortcut for closing the routine pieces
-      end -- Front trigger for closing panels
-    end -- This is client closing the routine pieces
-  end
+  if(not asmlib.IsModel(model)) then return end
+  local bO = asmlib.IsFlag("old_close_frame", asmlib.IsFlag("new_close_frame"))
+  local bN = asmlib.IsFlag("new_close_frame", inputIsKeyDown(KEY_E))
+  if(not bO and bN and inputIsKeyDown(KEY_LALT)) then
+    local oD = conElements:Pull() -- Retrieve a panel from the stack
+    if(asmlib.IsTable(oD)) then oD = oD[1] -- Extract panel from table
+      if(IsValid(oD)) then oD:SetVisible(false) end -- Make it invisible
+    else -- The temporary reference is not table then close it
+      if(IsValid(oD)) then oD:Close() end -- A `close` call, get it :D
+    end -- Shortcut for closing the routine pieces
+  end -- Front trigger for closing panels
 end
 
 --[[

--- a/lua/weapons/gmod_tool/stools/trackassembly.lua
+++ b/lua/weapons/gmod_tool/stools/trackassembly.lua
@@ -1406,7 +1406,7 @@ function TOOL:LeftClick(stTrace)
           if(applinfst) then nextx  , nexty  , nextz  , applinfst = 0, 0, 0, false end
           asmlib.GetEntitySpawn(oPly, ePiece, oArg.vtemp, model, pointid,
             actrad, spnflat, igntype, nextx, nexty, nextz, nextpic, nextyaw, nextrol, oArg.spawn)
-          if(not oArg.spawn) then -- Something happend spawn is not available and task must be removed
+          if(not oArg.spawn) then -- Something happened spawn is not available and task must be removed
             asmlib.Notify(oPly,"Cannot obtain spawn data !", "ERROR")
             asmlib.LogInstance(self:GetStatus(stTrace,"(Stack) "..sItr..": Cannot obtain spawn data"),gtLogs); return false
           end -- Spawn data is valid for the current iteration iNdex
@@ -2387,7 +2387,7 @@ function TOOL.BuildCPanel(CPanel)
         pComboToolMode:SetSortItems(false)
         pComboToolMode:SetTooltip(languageGetPhrase("tool."..gsToolNameL..".workmode"))
         pComboToolMode:UpdateColours(drmSkin)
-        pComboToolMode:Dock(TOP) -- Setting tallness gets ingnored otherwise
+        pComboToolMode:Dock(TOP) -- Setting tallness gets ignored otherwise
         pComboToolMode:SetTall(22)
         pComboToolMode.DoRightClick = function(pnSelf) asmlib.SetComboBoxClipboard(pnSelf) end
         for iD = 1, conWorkMode:GetSize() do

--- a/lua/weapons/gmod_tool/stools/trackassembly.lua
+++ b/lua/weapons/gmod_tool/stools/trackassembly.lua
@@ -1583,7 +1583,7 @@ function TOOL:Reload(stTrace)
     end
     local trRec = asmlib.CacheQueryPiece(trEnt:GetModel())
     if(asmlib.IsHere(trRec) and (asmlib.GetOwner(trEnt) == user or user:IsAdmin())) then
-      asmlib.InSpawnMargin(trRec); trEnt:Remove()
+      asmlib.InSpawnMargin(user, trRec); trEnt:Remove()
       asmlib.LogInstance("(Prop) Remove piece",gtLogs); return true
     end; asmlib.LogInstance("(Prop) Success",gtLogs)
   end; return false


### PR DESCRIPTION
Currently TA can still hit the limit of the internally stored models in the source engine via calling `util.IsValidModel` directly or triggering a `ENT:SetModel` routine that later fills a space in this array too. When registering transform we have
```lua
  164 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] IsModel: File >> {nil}|true|models/ron/plarail/scenery/aj01.mdl|
  165 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] MakeEntityNone: Create {2}|models/ron/plarail/scenery/aj01.mdl|
  166 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {1}|0.000000 0.000000 0.000000|-0.000 90.000 0.000|
  167 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {2}|-0.000008 175.999985 0.000000|-0.000 -90.000 0.000|
  168 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] IsModel: File >> {nil}|true|models/ron/plarail/scenery/aj01_2.mdl|
  169 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Update {2}|models/ron/plarail/scenery/aj01_2.mdl|
  170 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {1}|0.000000 0.000000 0.000000|-0.000 90.000 0.000|
  171 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {2}|-0.000004 87.999992 0.000000|-0.000 -90.000 0.000|
  172 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] IsModel: File >> {nil}|true|models/ron/plarail/scenery/aj02.mdl|
  173 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Update {2}|models/ron/plarail/scenery/aj02.mdl|
  174 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {1}|0.000000 0.000000 0.000000|-0.000 90.000 0.000|
  175 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {2}|0.000000 0.000000 -35.999996|-0.000 90.000 0.000|
  176 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] IsModel: File >> {nil}|true|models/ron/plarail/scenery/aj03.mdl|
  177 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Update {2}|models/ron/plarail/scenery/aj03.mdl|
  178 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {1}|0.000000 0.000000 0.000000|-0.000 -90.000 0.000|
  179 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {2}|-0.000004 87.999992 0.000000|-0.000 90.000 0.000|
  180 [24-03-24 19:13:42] SERVER > TRACKASSEMBLY [LUA] GetTransformOA: Extract {3}|-0.000004 87.999992 35.999996|-0.000 90.000 0.000|
```
This caches a transform POA dummy entity which is used to extract the parameters for model `X`, however every `ENT:SetModel` call on this entity fills one slot in the internal strings table of 4K limit

Possible resolution: Adjust `asmlib.GetNormalSpawn` or some of its internal routines ( most likely `LocatePOA` ). The idea is that if a model is chosen from the user it will be ghosted. So if it does, the entity must be spawned and a slot will be filled anyway. In this case the transform temporary entity can be used for extracting the position and angle. Currently TA in `Lua` database mode will call the extraction for every model in the database parametrized to use transform attachments with notation `!<attachment_id>` for points, origins and angles ( `POA` ). The `DB` cache must obtain a KV pair that stores the current initialization status if the picked model and to extract it only if needed a.k.a. when this internal flag is `false` ( attachment not yet loaded ). Loading the attachment will trigger this flag to `true` and one model will be inserted in the internal game model cache.